### PR TITLE
Add BRAIN Initiative talk as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "2019-BRAINI-PanNeuro-slides"]
+	path = 2019-BRAINI-PanNeuro-slides
+	url = https://github.com/arokem/2019-BRAINI-PanNeuro-slides


### PR DESCRIPTION
This adds a submodule with slides from a talk I am going to give in April. 

Question: do we want to use submodules? It does complicate the git workflow a bit (I had to carefully follow this page: https://git-scm.com/book/en/v2/Git-Tools-Submodules), but seems to support the kind of pattern we'd presumably want here (?).